### PR TITLE
Make soseki installable with pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,13 @@ BPR was originally developed to achieve high computational efficiency of the QA 
 # Before installation, upgrade pip and setuptools
 $ pip install -U pip setuptools
 
+# For reproducing experiments, install dependencies with sepcific versions beforehand
+$ pip install -r requirements.txt
+
 # Install the soseki package
 $ pip install .
-# Or if you want to install it in development mode
-$ pip install --editable .
+# If you want to install it in editable mode
+$ pip install -e .
 ```
 
 **Note:** If you are using a GPU Environment different from CUDA 10.2, you may need to reinstall PyTorch according to [the official documentation](https://pytorch.org/get-started/locally/).

--- a/README.md
+++ b/README.md
@@ -7,10 +7,14 @@ BPR was originally developed to achieve high computational efficiency of the QA 
 
 ## Installation
 
-You can install the required libraries using pip:
-
 ```sh
-$ pip install -r requirements.txt
+# Before installation, upgrade pip and setuptools
+$ pip install -U pip setuptools
+
+# Install the soseki package
+$ pip install .
+# Or if you want to install it in development mode
+$ pip install --editable .
 ```
 
 **Note:** If you are using a GPU Environment different from CUDA 10.2, you may need to reinstall PyTorch according to [the official documentation](https://pytorch.org/get-started/locally/).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,0 @@
-faiss-cpu
-lmdb
-onnxruntime
-pytorch-lightning==1.4.9
-regex
-streamlit
-torch==1.10.1
-tqdm
-transformers==4.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+faiss-cpu==1.7.2
+lmdb==1.3.0
+onnxruntime==1.10.0
+pytorch-lightning==1.4.9
+regex==2022.1.18
+streamlit==1.6.0
+torch==1.10.1
+tqdm==4.63.0
+transformers==4.15.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,9 +12,9 @@ install_requires =
     faiss-cpu
     lmdb
     onnxruntime
-    pytorch-lightning == 1.4.9
+    pytorch-lightning
     regex
     streamlit
-    torch == 1.10.1
+    torch
     tqdm
-    transformers == 4.15.0
+    transformers

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,20 @@
+[metadata]
+name = soseki
+version = 0.0.1
+description = Open domain QA system by Studio Ousia
+author = Studio Ousia
+url = https://github.com/studio-ousia/soseki
+license = Creative Commons Attribution-NonCommercial 4.0 International License
+
+[options]
+packages = soseki
+install_requires =
+    faiss-cpu
+    lmdb
+    onnxruntime
+    pytorch-lightning == 1.4.9
+    regex
+    streamlit
+    torch == 1.10.1
+    tqdm
+    transformers == 4.15.0


### PR DESCRIPTION
This PR makes the soseki package installable with pip.
Specifically, the package can be installed with `pip install .` or (`pip install --editable .`.)
