### PR TITLE
Remove `doublequote=False` option from csv.reader

### DIFF
--- a/soseki/passage_db/in_memory_passage_db.py
+++ b/soseki/passage_db/in_memory_passage_db.py
@@ -11,7 +11,7 @@ class InMemoryPassageDB:
     def __init__(self, passage_file: str, skip_header: bool = True):
         self.data = dict()
         with gzip.open(passage_file, "rt") if passage_file.endswith(".gz") else open(passage_file) as f:
-            tsv_reader = csv.reader(f, doublequote=False, delimiter="\t")
+            tsv_reader = csv.reader(f, delimiter="\t")
             for i, row in tqdm(enumerate(tsv_reader)):
                 if i == 0 and skip_header:
                     continue

--- a/soseki/passage_db/lmdb_passage_db.py
+++ b/soseki/passage_db/lmdb_passage_db.py
@@ -48,7 +48,7 @@ class LMDBPassageDB:
         db = lmdb.open(db_file, map_size=db_map_size, subdir=False)
         with db.begin(write=True) as txn:
             with gzip.open(passage_file, "rt") if passage_file.endswith(".gz") else open(passage_file) as f:
-                tsv_reader = csv.reader(f, doublequote=False, delimiter="\t")
+                tsv_reader = csv.reader(f, delimiter="\t")
                 buffer = []
                 for i, row in tqdm(enumerate(tsv_reader)):
                     if i == 0 and skip_header:


### PR DESCRIPTION
This PR removes `doublequote=False` options from `csv.reader`s for loading passage TSV files.

The option had been introduced to avoid errors when loading TSV files generated with `print(..., sep="\t")` function, but it also had introduced some errors when processing TSV files generated with `csv.writer`, which seems to be used when generating DPR's passage files.