### PR TITLE
Support evaluation of a retriever restricting to the same dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ $ python build_passage_embeddings.py \
     --output_file <WORK_DIR>/passage_embeddings.idx \
     --max_passage_length 192 \
     --batch_size 2048 \
-    --device_ids 0,1,2,3
+    --device_ids 0 1 2 3
 ```
 
 **4. Evaluate the retriever and create datasets for reader**
@@ -89,12 +89,12 @@ $ python evaluate_retriever.py \
     --output_file <WORK_DIR>/reader_data/nq_train.jsonl \
     --batch_size 64 \
     --max_question_length 64 \
-    --top_k 1,2,5,10,20,50,100 \
+    --top_k 1 2 5 10 20 50 100 \
     --binary \
     --binary_k 2048 \
     --answer_match_type dpr_string \
     --include_title_in_passage \
-    --device_ids 0,1,2,3
+    --device_ids 0 1 2 3
 # The result should be logged as follows:
 # Recall at 1: 0.4867 (38529/79168)
 # Recall at 2: 0.6059 (47964/79168)
@@ -112,12 +112,12 @@ $ python evaluate_retriever.py \
     --output_file <WORK_DIR>/reader_data/nq_dev.jsonl \
     --batch_size 64 \
     --max_question_length 64 \
-    --top_k 1,2,5,10,20,50,100 \
+    --top_k 1 2 5 10 20 50 100 \
     --binary \
     --binary_k 2048 \
     --answer_match_type dpr_string \
     --include_title_in_passage \
-    --device_ids 0,1,2,3
+    --device_ids 0 1 2 3
 # The result should be logged as follows:
 # Recall at 1: 0.3984 (3489/8757)
 # Recall at 2: 0.5085 (4453/8757)
@@ -135,12 +135,12 @@ $ python evaluate_retriever.py \
     --output_file <WORK_DIR>/reader_data/nq_test.jsonl \
     --batch_size 64 \
     --max_question_length 64 \
-    --top_k 1,2,5,10,20,50,100 \
+    --top_k 1 2 5 10 20 50 100 \
     --binary \
     --binary_k 2048 \
     --answer_match_type dpr_string \
     --include_title_in_passage \
-    --device_ids 0,1,2,3
+    --device_ids 0 1 2 3
 # The result should be logged as follows:
 # Recall at 1: 0.4058 (1465/3610)
 # Recall at 2: 0.5191 (1874/3610)

--- a/build_passage_db.py
+++ b/build_passage_db.py
@@ -19,7 +19,6 @@ def main(args: Namespace) -> None:
         args.passage_file,
         args.db_file,
         db_map_size=args.db_map_size,
-        skip_header=args.skip_header,
         chunk_size=args.chunk_size,
     )
     logger.info("Finished building LMDBPassageDB")
@@ -31,7 +30,6 @@ if __name__ == "__main__":
     parser.add_argument("--passage_file", type=str, required=True)
     parser.add_argument("--db_file", type=str, required=True)
     parser.add_argument("--db_map_size", type=int, default=2147483648)
-    parser.add_argument("--skip_header", action="store_true")
     parser.add_argument("--chunk_size", type=int, default=1024)
     args = parser.parse_args()
 

--- a/build_passage_embeddings.py
+++ b/build_passage_embeddings.py
@@ -18,10 +18,10 @@ def main(args: Namespace):
     biencoder.passage_encoder.eval()
 
     if args.device_ids is not None:
-        device_ids = [int(i) for i in args.device_ids.split(",")]
-        biencoder.passage_encoder.to(device_ids[0])
+        device_ids = args.device_ids
+        question_encoder.to(device_ids[0])
         if len(device_ids) > 1:
-            biencoder.passage_encoder = DataParallel(biencoder.passage_encoder, device_ids=device_ids)
+            question_encoder = DataParallel(question_encoder, device_ids=device_ids)
     else:
         device_ids = []
 

--- a/build_passage_embeddings.py
+++ b/build_passage_embeddings.py
@@ -19,9 +19,9 @@ def main(args: Namespace):
 
     if args.device_ids is not None:
         device_ids = args.device_ids
-        question_encoder.to(device_ids[0])
+        biencoder.passage_encoder.to(device_ids[0])
         if len(device_ids) > 1:
-            question_encoder = DataParallel(question_encoder, device_ids=device_ids)
+            biencoder.passage_encoder = DataParallel(biencoder.passage_encoder, device_ids=device_ids)
     else:
         device_ids = []
 

--- a/evaluate_retriever.py
+++ b/evaluate_retriever.py
@@ -87,10 +87,10 @@ def passage_has_answer(answer: str, passage: str, match_type: str = "dpr_string"
 
 
 def read_qa_file(qa_file: str):
-    for row in readitem_tsv(qa_file):
-        question = row[0]
-        answers = ast.literal_eval(row[1])
-        yield question, answers, None
+    for row in readitem_tsv(qa_file, fieldnames=["question", "answers"]):
+        question = row["question"]
+        answers = ast.literal_eval(row["answers"])
+        yield question, answers, None, None
 
 
 def read_retriever_file(retriever_file: str):
@@ -98,7 +98,8 @@ def read_retriever_file(retriever_file: str):
         question = item["question"]
         answers = item["answers"]
         positive_passage_ids = [str(ctx["passage_id"]) for ctx in item["positive_ctxs"]]
-        yield question, answers, positive_passage_ids
+        dataset = item.get("dataset", None)
+        yield question, answers, positive_passage_ids, dataset
 
 
 def main(args: Namespace):
@@ -113,7 +114,7 @@ def main(args: Namespace):
     encoder_tokenization = biencoder.tokenization
 
     if args.device_ids is not None:
-        device_ids = [int(i) for i in args.device_ids.split(",")]
+        device_ids = args.device_ids
         question_encoder.to(device_ids[0])
         if len(device_ids) > 1:
             question_encoder = DataParallel(question_encoder, device_ids=device_ids)
@@ -129,8 +130,11 @@ def main(args: Namespace):
         retriever = DenseRetriever(args.passage_embeddings_file, args.passage_db_file)
 
     num_passages = len(retriever.passage_db)
-    top_ks = [int(k) for k in args.top_k.split(",")]
-    retrieval_k = max(top_ks)
+
+    if args.retrieval_k is not None:
+        retrieval_k = args.retrieval_k
+    else:
+        retrieval_k = max(args.top_k)
 
     positive_ranks = []
     output_items = []
@@ -142,7 +146,7 @@ def main(args: Namespace):
 
     with tqdm() as pbar:
         for batch_tuples in batch_iter(dataset_iterator, batch_size=args.batch_size):
-            questions, answer_lists, positive_passage_id_lists = list(zip(*batch_tuples))
+            questions, answer_lists, positive_passage_id_lists, datasets = list(zip(*batch_tuples))
             with torch.no_grad():
                 encoder_inputs = dict(
                     encoder_tokenization.tokenize_questions(
@@ -165,9 +169,17 @@ def main(args: Namespace):
             else:
                 retrieved_passage_lists = retriever.retrieve_top_k_passages(encoded_questions, k=retrieval_k)
 
-            for question, answers, positive_passage_ids, retrieved_passages in zip(
-                questions, answer_lists, positive_passage_id_lists, retrieved_passage_lists
+            for question, answers, positive_passage_ids, dataset, retrieved_passages in zip(
+                questions, answer_lists, positive_passage_id_lists, datasets, retrieved_passage_lists
             ):
+                if args.restrict_to_same_dataset:
+                    if dataset is None:
+                        raise ValueError(
+                            "The option --restrict_to_same_dataset is set but the input item has no dataset value."
+                        )
+
+                    retrieved_passages = [passage for passage in retrieved_passages if passage.dataset == dataset]
+
                 positive_rank = None
                 output_ctxs = []
                 for rank, retrieved_passage in enumerate(retrieved_passages, start=1):
@@ -195,7 +207,7 @@ def main(args: Namespace):
 
             pbar.update(len(batch_tuples))
 
-    for k in sorted(top_ks):
+    for k in sorted(args.top_k):
         num_correct_at_k = sum(int(rank <= k) for rank in positive_ranks)
         recall_at_k = num_correct_at_k / len(positive_ranks)
         logger.info(f"Recall at {k}: {recall_at_k:.4f} ({num_correct_at_k}/{len(positive_ranks)})")
@@ -215,12 +227,14 @@ if __name__ == "__main__":
     parser.add_argument("--eval_mode", choices=("has_answer", "is_labeled_positive"), default="has_answer")
     parser.add_argument("--batch_size", type=int, default=8)
     parser.add_argument("--max_question_length", type=int, default=256)
-    parser.add_argument("--top_k", type=str, default="1,5,20,50,100")
+    parser.add_argument("--top_k", type=int, nargs="+", default=[1, 5, 20, 50, 100])
     parser.add_argument("--binary", action="store_true")
     parser.add_argument("--binary_k", type=int, default=2048)
+    parser.add_argument("--retrieval_k", type=int)
+    parser.add_argument("--restrict_to_same_dataset", action="store_true")
     parser.add_argument("--answer_match_type", type=str, default="dpr_string")
     parser.add_argument("--include_title_in_passage", action="store_true")
-    parser.add_argument("--device_ids", type=str)
+    parser.add_argument("--device_ids", type=int, nargs="+")
     args = parser.parse_args()
 
     main(args)

--- a/soseki/passage_db/in_memory_passage_db.py
+++ b/soseki/passage_db/in_memory_passage_db.py
@@ -6,19 +6,18 @@ from ..utils.data_utils import Passage, readitem_tsv
 
 
 class InMemoryPassageDB:
-    def __init__(self, passage_file: str, skip_header: bool = True):
+    def __init__(self, passage_file: str):
         self.data = dict()
-        for row in tqdm(readitem_tsv(passage_file, skip_header=skip_header)):
-            passage_id, text, title = row[0], row[1], row[2]
-            self.data[int(passage_id)] = (text, title)
+        for row in tqdm(readitem_tsv(passage_file)):
+            self.data[int(row["id"])] = (row["title"], row["text"], row.get("dataset", None))
 
     def __len__(self):
         return len(self.data)
 
     def __getitem__(self, passage_id: int) -> Passage:
-        text, title = self.data[passage_id]
-        return Passage(passage_id, title, text)
+        title, text, dataset = self.data[passage_id]
+        return Passage(passage_id, title, text, dataset=dataset)
 
     def __iter__(self) -> Iterator[Passage]:
-        for passage_id, (text, title) in self.data.items():
-            yield Passage(passage_id, title, text)
+        for passage_id, (text, title, dataset) in self.data.items():
+            yield Passage(passage_id, title, text, dataset=dataset)

--- a/soseki/retriever/binary_retriever.py
+++ b/soseki/retriever/binary_retriever.py
@@ -56,7 +56,13 @@ class BinaryRetriever:
             for score, passage_id in zip(scores, passage_ids):
                 passage = self.passage_db[int(passage_id)]
                 retrieved_passages.append(
-                    RetrievedPassage(id=passage.id, title=passage.title, text=passage.text, score=float(score))
+                    RetrievedPassage(
+                        id=passage.id,
+                        title=passage.title,
+                        text=passage.text,
+                        dataset=passage.dataset,
+                        score=float(score),
+                    )
                 )
 
             outputs.append(sorted(retrieved_passages, key=lambda p: p.score, reverse=True)[:k])

--- a/soseki/retriever/dense_retriever.py
+++ b/soseki/retriever/dense_retriever.py
@@ -38,7 +38,13 @@ class DenseRetriever:
             for score, passage_id in zip(scores, passage_ids):
                 passage = self.passage_db[int(passage_id)]
                 retrieved_passages.append(
-                    RetrievedPassage(id=passage.id, title=passage.title, text=passage.text, score=float(score))
+                    RetrievedPassage(
+                        id=passage.id,
+                        title=passage.title,
+                        text=passage.text,
+                        dataset=passage.dataset,
+                        score=float(score),
+                    )
                 )
 
             outputs.append(sorted(retrieved_passages, key=lambda p: p.score, reverse=True))

--- a/soseki/utils/data_utils.py
+++ b/soseki/utils/data_utils.py
@@ -14,6 +14,7 @@ class Passage:
     id: int
     title: Optional[str] = None
     text: Optional[str] = None
+    dataset: Optional[str] = None
 
 
 @dataclass
@@ -199,12 +200,9 @@ def readitem_json(input_file: str, read_json_lines: Optional[bool] = None):
                 yield item
 
 
-def readitem_tsv(input_file: str, skip_header: bool = False):
+def readitem_tsv(input_file: str, fieldnames: Optional[List[str]] = None):
     with gzip.open(input_file, "rt") if input_file.endswith(".gz") else open(input_file) as f:
-        for i, row in enumerate(csv.reader(f, delimiter="\t")):
-            if i == 0 and skip_header:
-                continue
-
+        for row in csv.DictReader(f, fieldnames=fieldnames, delimiter="\t"):
             yield row
 
 


### PR DESCRIPTION
This PR adds support for evaluation of a retriever restricting the retrieved passages to be from the same dataset as input FAQ items.
Specifically, when running `evaluate_retriever.py`, setting `--restrict_to_same_dataset` option enables evaluation on the same dataset as each input FAQ item.