### PR TITLE
Fix a keyword argument in `build_passage_embeddings.py`

### DIFF
--- a/build_passage_embeddings.py
+++ b/build_passage_embeddings.py
@@ -87,7 +87,7 @@ if __name__ == "__main__":
     parser.add_argument("--output_file", type=str, required=True)
     parser.add_argument("--max_passage_length", type=int, default=256)
     parser.add_argument("--batch_size", type=int, default=128)
-    parser.add_argument("--device_ids", type=str)
+    parser.add_argument("--device_ids", type=int, nargs="+")
     args = parser.parse_args()
 
     main(args)


### PR DESCRIPTION
This PR fixes misconfiguration of a keyword argument in `build_passage_embeddings.py`, which has been introduced in https://github.com/studio-ousia/soseki/pull/5.